### PR TITLE
add discord permission check for chat bridge

### DIFF
--- a/src/main/java/com/kahzerx/kahzerxmod/extensions/discordExtension/DiscordListener.java
+++ b/src/main/java/com/kahzerx/kahzerxmod/extensions/discordExtension/DiscordListener.java
@@ -9,6 +9,9 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.IPermissionHolder;
+import net.dv8tion.jda.api.entities.Member;
 import net.minecraft.server.MinecraftServer;
 import org.jetbrains.annotations.NotNull;
 
@@ -106,10 +109,11 @@ public class DiscordListener extends ListenerAdapter {
             return;
         }
         TextChannel ch = jda.getTextChannelById(channelId);
-        if (ch != null) {
+        Member selfMember = ch.getGuild().getSelfMember();
+        if (ch != null && selfMember.hasAccess(ch)) {
             ch.sendMessage(discordSettings.getPrefix() + " " + msg).queue();
         } else {
-            System.out.println("Unable to find this Text Channel.");
+            System.out.println("Unable to find this Text Channel or missing permissions to view/send messages.");
         }
     }
 }


### PR DESCRIPTION
Prevent server crash from invalid permissions in discord. This will ensure that if someone accidentally plays with roles or the bot gets removed it will not crash the Minecraft server.